### PR TITLE
feat: Implement user registration screen

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -46,16 +46,28 @@ const logout = async () => {
 }
 
 const computedMenuItems = computed(() => {
-  const items = [...baseMenuItems.value]
+  const items = [...baseMenuItems.value]; // Start with base items
   if (authStore.user) {
     items.push({
       label: 'Sair',
       icon: 'pi pi-sign-out',
       command: logout
-    })
+    });
+  } else {
+    // If user is not logged in, add Login and Register
+    items.push({
+      label: 'Login',
+      icon: 'pi pi-sign-in',
+      command: () => router.push({ name: 'login' })
+    });
+    items.push({
+      label: 'Register',
+      icon: 'pi pi-user-plus',
+      command: () => router.push({ name: 'register' })
+    });
   }
-  return items
-})
+  return items;
+});
 </script>
 
 <template>

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -7,6 +7,7 @@ import {
 import { useAuthStore } from '@/stores/auth'
 import HomeView from '@/views/HomeView.vue'
 import LoginView from '@/views/LoginView.vue'
+import RegisterView from '@/views/RegisterView.vue'
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),
@@ -21,6 +22,12 @@ const router = createRouter({
       path: '/login',
       name: 'login',
       component: LoginView,
+      meta: { requiresAuth: false },
+    },
+    {
+      path: '/register',
+      name: 'register',
+      component: RegisterView,
       meta: { requiresAuth: false },
     },
     {
@@ -43,6 +50,8 @@ router.beforeEach(
     if (to.meta.requiresAuth && !isAuthenticated) {
       next({ name: 'login' })
     } else if (to.name === 'login' && isAuthenticated) {
+      next({ name: 'home' })
+    } else if (to.name === 'register' && isAuthenticated) {
       next({ name: 'home' })
     } else {
       next()

--- a/src/stores/auth.ts
+++ b/src/stores/auth.ts
@@ -1,6 +1,6 @@
 import { defineStore } from 'pinia'
 import api from '@/utils/axios'
-import type { User, AuthState, LoginCredentials } from '@/types/auth'
+import type { User, AuthState, LoginCredentials, RegisterCredentials } from '@/types/auth'
 
 export const useAuthStore = defineStore('auth', {
   state: (): AuthState => ({
@@ -21,6 +21,28 @@ export const useAuthStore = defineStore('auth', {
         return false
       } finally {
         this.isLoading = false
+      }
+    },
+
+    async register(credentials: RegisterCredentials): Promise<boolean> {
+      try {
+        this.isLoading = true;
+        // Assuming the register endpoint does not return a token directly or log the user in.
+        // If it does, the logic here might need to change (e.g., store token, fetch user).
+        await api.post('/auth/register', credentials);
+        // After successful registration, typically the user would be redirected to login,
+        // or automatically logged in. For now, just return true.
+        // The issue doesn't specify auto-login, so we'll assume they need to login after.
+        return true;
+      } catch (error) {
+        console.error('Registration failed:', error);
+        // You might want to inspect the error response to provide more specific feedback
+        // if (axios.isAxiosError(error) && error.response) {
+        //   // Handle specific error messages from backend
+        // }
+        return false;
+      } finally {
+        this.isLoading = false;
       }
     },
 

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,15 +1,4 @@
-export interface User {
-  email: string
-  role: string
-}
-
-export interface LoginCredentials {
-  email: string
-  senha: string
-}
-
-export interface AuthState {
-  user: User | null
-  isLoading: boolean
-  initialized: boolean
+export interface RegisterCredentials {
+  email: string;
+  senha: string;
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,22 +1,20 @@
 export interface User {
-  id: string; // Or number, depending on your backend
-  email: string;
-  // name?: string; // Example of another potential user field
-  // roles?: string[]; // Example for user roles
+  email: string
+  role: string[]
 }
 
 export interface AuthState {
-  user: User | null;
-  isLoading: boolean;
-  initialized: boolean; // To track if initial auth check is done
+  user: User | null
+  isLoading: boolean
+  initialized: boolean
 }
 
 export interface LoginCredentials {
-  email: string;
-  senha: string;
+  email: string
+  senha: string
 }
 
 export interface RegisterCredentials {
-  email: string;
-  senha: string;
+  email: string
+  senha: string
 }

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -1,3 +1,21 @@
+export interface User {
+  id: string; // Or number, depending on your backend
+  email: string;
+  // name?: string; // Example of another potential user field
+  // roles?: string[]; // Example for user roles
+}
+
+export interface AuthState {
+  user: User | null;
+  isLoading: boolean;
+  initialized: boolean; // To track if initial auth check is done
+}
+
+export interface LoginCredentials {
+  email: string;
+  senha: string;
+}
+
 export interface RegisterCredentials {
   email: string;
   senha: string;

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -3,14 +3,15 @@
     <div class="">
       <Form :resolver @submit="handleLogin" class="">
         <FormField v-slot="$field" as="section" name="username" initialValue="{{ credentials.email }}" class="">
-          <InputText v-model="credentials.email" type="text" placeholder="Username" />
+          <InputText v-model="credentials.email" type="text" placeholder="Username" fluid />
           <Message v-if="$field?.invalid" severity="error" size="small" variant="simple">
             {{ $field.error?.message }}
           </Message>
         </FormField>
         <FormField v-slot="$field" asChild name="password" initialValue="{{ credentials.senha }}">
           <section class="">
-            <Password v-model="credentials.senha" type="text" placeholder="Password" :feedback="false" toggleMask />
+            <Password v-model="credentials.senha" type="text" placeholder="Password" :feedback="false" toggleMask
+              fluid />
             <Message v-if="$field?.invalid" severity="error" size="small" variant="simple">
               {{ $field.error?.message }}
             </Message>
@@ -18,7 +19,8 @@
         </FormField>
         <Button type="submit" :disabled="isLoading" label="Login" icon="pi pi-user" iconPos="right" />
         <Message v-if="error" severity="error" variant="outlined">{{ error }}</Message>
-        <Button label="Don't have an account? Register here" link @click="navigateToRegister" class="p-mt-2" />
+        <Button label="Não possui uma conta? Registre-se" icon="pi pi-user-plus" link @click="navigateToRegister"
+          class="p-mt-2" />
       </Form>
     </div>
   </div>

--- a/src/views/LoginView.vue
+++ b/src/views/LoginView.vue
@@ -18,6 +18,7 @@
         </FormField>
         <Button type="submit" :disabled="isLoading" label="Login" icon="pi pi-user" iconPos="right" />
         <Message v-if="error" severity="error" variant="outlined">{{ error }}</Message>
+        <Button label="Don't have an account? Register here" link @click="navigateToRegister" class="p-mt-2" />
       </Form>
     </div>
   </div>
@@ -82,4 +83,8 @@ const handleLogin = async (e: { valid: unknown }) => {
     }
   }
 }
+
+const navigateToRegister = () => {
+  router.push({ name: 'register' });
+};
 </script>

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -1,0 +1,76 @@
+<template>
+  <div class="">
+    <div class="">
+      <Form :resolver="resolver" @submit="handleRegister" class="">
+        <FormField v-slot="$field" as="section" name="email" class="">
+          <InputText v-model="credentials.email" type="email" placeholder="Email" />
+          <Message v-if="$field?.invalid" severity="error" size="small" variant="simple">
+            {{ $field.error?.message }}
+          </Message>
+        </FormField>
+        <FormField v-slot="$field" asChild name="senha">
+          <section class="">
+            <Password v-model="credentials.senha" placeholder="Password" :feedback="true" toggleMask />
+            <Message v-if="$field?.invalid" severity="error" size="small" variant="simple">
+              {{ $field.error?.message }}
+            </Message>
+          </section>
+        </FormField>
+        <Button type="submit" :disabled="isLoading" label="Register" icon="pi pi-user-plus" iconPos="right" />
+        <Message vif="error" severity="error" variant="outlined">{{ error }}</Message>
+      </Form>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter } from 'vue-router'
+import { useAuthStore } from '@/stores/auth'
+import type { RegisterCredentials } from '@/types/auth' // Assuming RegisterCredentials will be defined
+import { zodResolver } from '@primevue/forms/resolvers/zod';
+import { z } from 'zod';
+
+const router = useRouter()
+const authStore = useAuthStore()
+const credentials = ref<RegisterCredentials>({ email: '', senha: '' })
+const error = ref<string>('')
+const isLoading = ref<boolean>(false)
+
+const passwordSchema = z
+  .string()
+  .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/, {
+    message: "Password must be at least 8 characters long, include uppercase, lowercase, number, and a special character (@$!%*?&)."
+  });
+
+const resolver = zodResolver(
+  z.object({
+    email: z.string().min(1, { message: 'Email is required.' }).email({ message: 'Invalid email address.' }),
+    senha: passwordSchema,
+  })
+);
+
+const handleRegister = async (e: { valid: unknown }) => {
+  if (e.valid) {
+    try {
+      isLoading.value = true;
+      const success = await authStore.register(credentials.value); // Call the new action
+      if (success) {
+        // Redirect to login page after successful registration
+        // Or show a success message and let them navigate manually
+        router.push({ name: 'login' });
+        // Optionally, display a success message to the user (e.g., using a toast notification)
+      } else {
+        error.value = 'Registration failed. Please try again or contact support.';
+      }
+    } catch (err) {
+      console.error(err);
+      // This catch might be redundant if authStore.register handles its own errors
+      // and returns false, but good for unexpected issues.
+      error.value = 'An unexpected error occurred during registration.';
+    } finally {
+      isLoading.value = false;
+    }
+  }
+}
+</script>

--- a/src/views/RegisterView.vue
+++ b/src/views/RegisterView.vue
@@ -2,22 +2,25 @@
   <div class="">
     <div class="">
       <Form :resolver="resolver" @submit="handleRegister" class="">
-        <FormField v-slot="$field" as="section" name="email" class="">
-          <InputText v-model="credentials.email" type="email" placeholder="Email" />
-          <Message v-if="$field?.invalid" severity="error" size="small" variant="simple">
-            {{ $field.error?.message }}
+        <FormField v-slot="$fieldEmail" as="section" name="email" class="">
+          <InputText v-model="credentials.email" type="email" placeholder="Email" fluid />
+          <Message v-if="$fieldEmail?.invalid" severity="error" size="small" variant="simple">
+            {{ $fieldEmail.error?.message }}
           </Message>
         </FormField>
-        <FormField v-slot="$field" asChild name="senha">
+        <FormField v-slot="$fieldPassword" asChild name="senha">
           <section class="">
-            <Password v-model="credentials.senha" placeholder="Password" :feedback="true" toggleMask />
-            <Message v-if="$field?.invalid" severity="error" size="small" variant="simple">
-              {{ $field.error?.message }}
+            <Password v-model="credentials.senha" placeholder="Senha@2025" :feedback="true" toggleMask fluid />
+            <Message v-if="$fieldPassword?.invalid" severity="error" size="small" variant="simple">
+              {{ $fieldPassword.error?.message }}
             </Message>
           </section>
         </FormField>
         <Button type="submit" :disabled="isLoading" label="Register" icon="pi pi-user-plus" iconPos="right" />
-        <Message vif="error" severity="error" variant="outlined">{{ error }}</Message>
+        <Button label="Já possui uma conta? Faça login" icon="pi pi-user-plus" link @click="navigateToLogin"
+          class="p-mt-2" />
+        <Message v-if="error" severity="error" variant="outlined">{{ error }}</Message>
+        <Message v-if="success" severity="success" variant="outlined">{{ success }}</Message>
       </Form>
     </div>
   </div>
@@ -35,17 +38,18 @@ const router = useRouter()
 const authStore = useAuthStore()
 const credentials = ref<RegisterCredentials>({ email: '', senha: '' })
 const error = ref<string>('')
+const success = ref<string>('')
 const isLoading = ref<boolean>(false)
 
 const passwordSchema = z
   .string()
   .regex(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/, {
-    message: "Password must be at least 8 characters long, include uppercase, lowercase, number, and a special character (@$!%*?&)."
+    message: "A senha deve ter pelo menos 8 caracteres, incluir letras maiúsculas, minúsculas, números e um caractere especial (@$!%*?&)."
   });
 
 const resolver = zodResolver(
   z.object({
-    email: z.string().min(1, { message: 'Email is required.' }).email({ message: 'Invalid email address.' }),
+    email: z.string().min(1, { message: 'Email é obrigatório.' }).email({ message: 'Email inválido.' }),
     senha: passwordSchema,
   })
 );
@@ -54,23 +58,23 @@ const handleRegister = async (e: { valid: unknown }) => {
   if (e.valid) {
     try {
       isLoading.value = true;
-      const success = await authStore.register(credentials.value); // Call the new action
-      if (success) {
-        // Redirect to login page after successful registration
-        // Or show a success message and let them navigate manually
+      const result = await authStore.register(credentials.value);
+      if (result) {
+        success.value = 'Registro bem-sucedido! Agora você pode fazer login.';
         router.push({ name: 'login' });
-        // Optionally, display a success message to the user (e.g., using a toast notification)
       } else {
-        error.value = 'Registration failed. Please try again or contact support.';
+        error.value = 'Registro falhou. Por favor, tente novamente.';
       }
     } catch (err) {
       console.error(err);
-      // This catch might be redundant if authStore.register handles its own errors
-      // and returns false, but good for unexpected issues.
-      error.value = 'An unexpected error occurred during registration.';
+      error.value = 'Um erro ocorreu durante o registro. Por favor, tente novamente.';
     } finally {
       isLoading.value = false;
     }
   }
 }
+
+const navigateToLogin = () => {
+  router.push({ name: 'login' });
+};
 </script>


### PR DESCRIPTION
Adds a new registration screen accessible via `/register`.

Key changes include:
- Created `RegisterView.vue` with a form for email and password.
- Implemented password validation using Zod to enforce complexity:
    - Minimum 8 characters
    - At least one lowercase letter
    - At least one uppercase letter
    - At least one digit
    - At least one special character from [@$!%*?&]
    - Only allows alphanumeric and specified special characters.
- Added a route for `/register` in `src/router/index.ts`, accessible only to unauthenticated users. Authenticated users are redirected to home.
- Added a link to the registration page from the `LoginView.vue`.
- Added "Register" and "Login" links to the main menu in `src/App.vue` for unauthenticated users.
- Updated `src/stores/auth.ts` with a `register` action to handle the API call to `/auth/register`.
- Upon successful registration, you are redirected to the login page.
- Ensured UI consistency using PrimeVue components.